### PR TITLE
Fe/feature/quest encounters

### DIFF
--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -20,6 +20,7 @@ const updateData = (path: string, action: string, data: object) => {
     body: JSON.stringify(data),
   }).then((response) => {
     if (response.ok) {
+      console.log("hey i am at updateData")
       return response.json();
     } else {
       throw new Error(
@@ -43,13 +44,13 @@ export const apiCalls = {
   },
 
   getQuestEncounter: (questId: number, progressLevel: number) => {
-    console.log(questId, progressLevel);
     return getData(
       `${baseUrl}/quests/${questId}/encounters?progress=${progressLevel}`
     );
   },
 
-  patchUserQuest: (userProgress: object) => {
-    return updateData(`${baseUrl}/users/1/quests`, "PATCH", userProgress);
-  },
+  patchUserQuest: (userId: string, userProgress: object) => {
+    console.log("Hey I am here at patchUserQuest apiCalls:" + " " + userId + userProgress)
+    return updateData(`${baseUrl}/users/${userId}/quests`, "PATCH", userProgress);
+  }
 };

--- a/src/apiCalls.tsx
+++ b/src/apiCalls.tsx
@@ -20,7 +20,6 @@ const updateData = (path: string, action: string, data: object) => {
     body: JSON.stringify(data),
   }).then((response) => {
     if (response.ok) {
-      console.log("hey i am at updateData")
       return response.json();
     } else {
       throw new Error(
@@ -50,7 +49,6 @@ export const apiCalls = {
   },
 
   patchUserQuest: (userId: string, userProgress: object) => {
-    console.log("Hey I am here at patchUserQuest apiCalls:" + " " + userId + userProgress)
     return updateData(`${baseUrl}/users/${userId}/quests`, "PATCH", userProgress);
   }
 };

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -74,3 +74,8 @@ export interface MenuProps {
 export interface MenuItemProps {
   path: string
 }
+
+export interface Heart {
+  image: object,
+  id: number
+}

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -20,6 +20,10 @@ export interface Quest extends idObject {
   progress: number
 }
 
+export interface CompletedQuests {
+  completedQuests: Array<Quest>;
+}
+
 export interface QuestInProgress extends Quest {
   level: number
 }

--- a/src/interfaces.tsx
+++ b/src/interfaces.tsx
@@ -1,7 +1,11 @@
-export interface Profile {
+export interface UserProfile {
   username: string 
   email: string
   xp: number
+}
+
+export interface ProfileObject {
+  user: UserProfile;
 }
 
 export interface idObject {

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -8,12 +8,8 @@ import HomePage from "../HomePage";
 import QuestsList from "../QuestsList";
 import userRoutes from "../../routes/user";
 import { Route, Switch, useParams } from "react-router-dom";
-import testData from "../test_assets/mock_data";
 import { QuestInProgress } from "../../interfaces";
 import { apiCalls } from "../../apiCalls";
-
-//mock data
-const quests = testData.quests;
 
 const App = () => {
   const [user, setUser] = useState<any | null>(null);
@@ -27,23 +23,22 @@ const App = () => {
   };
 
   const getCompletedQuests = () => {
-    Promise.resolve(apiCalls.getQuests("1", true)).then((response) =>
+    Promise.resolve(apiCalls.getQuests("8", true)).then((response) =>
       setCompletedQuests(questCleaner(response.data.attributes.quests))
     );
   };
 
   const getQuestDetails = () => {
-    Promise.resolve(apiCalls.getQuests("3", false)).then((response) =>
-      setAvailableQuests(response.data.attributes.quests)
-    );
-  };
+    Promise.resolve(apiCalls.getQuests("8", false))
+    .then((response) => setAvailableQuests(response.data.attributes.quests.map(quest => Object.values(quest)[0])
+  ))
+}
 
   const questCleaner = (badQuests: Array<object>) => {
     console.log(badQuests);
     return badQuests.map((badQuest) => Object.values(badQuest)[0]);
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => getUserInfo(), []);
   useEffect(() => getQuestDetails(), []);
 
@@ -67,7 +62,7 @@ const App = () => {
             render={({ match }) => (
               <Quest
                 getQuestDetails={getQuestDetails}
-                quests={quests}
+                quests={availableQuests}
                 match={match}
               />
             )}
@@ -77,7 +72,7 @@ const App = () => {
               exact
               path={userRoutes.availableQuests.path}
               render={({ match }) => (
-                <QuestsList quests={quests} match={match} />
+                <QuestsList quests={availableQuests} match={match} />
               )}
             />
           )}

--- a/src/modules/App/index.tsx
+++ b/src/modules/App/index.tsx
@@ -17,7 +17,7 @@ const App = () => {
   const [availableQuests, setAvailableQuests] = useState<QuestInProgress[]>([]);
 
   const getUserInfo = () => {
-    Promise.resolve(apiCalls.getUser({ email: "olga@example.com" }))
+    Promise.resolve(apiCalls.getUser({ email: "george@example.com" }))
       .then((response) => setUser(response.data.attributes))
       .then((response) => getCompletedQuests());
   };
@@ -35,7 +35,6 @@ const App = () => {
 }
 
   const questCleaner = (badQuests: Array<object>) => {
-    console.log(badQuests);
     return badQuests.map((badQuest) => Object.values(badQuest)[0]);
   };
 

--- a/src/modules/HomePage/index.tsx
+++ b/src/modules/HomePage/index.tsx
@@ -2,16 +2,9 @@ import React from "react";
 import { Link } from "react-router-dom";
 import Menu from "../Common/Menu";
 import MenuItem from "../Common/MenuItem";
-import Grid from "../../ui/Grid/Grid";
-import Profile from "../User";
-import UserQuestLog from "../UserQuestLog";
-import { useEffect, useState } from "react";
 import userRoutes from "../../routes/user";
-import ProfileTabActive from "../../assets/Tabs/Tab_UserProfile_Active.png";
 import ProfileTab from "../../assets/Tabs/Tab_UserProfile_Inactive.png";
-import QuestsTabActive from "../../assets/Tabs/Tab_NewQuests_Active.png";
 import QuestsTab from "../../assets/Tabs/Tab_NewQuests_Inactice.png";
-import QuestLogTabActive from "../../assets/Tabs/Tab_QuestLog_Active.png";
 import QuestLogTab from "../../assets/Tabs/Tab_QuestLog_Inactive.png";
 import "./HomePage.scss";
 
@@ -21,8 +14,6 @@ interface HomePageProps {
 
 const HomePage: React.FC<HomePageProps> = (props) => {
   const { children } = props;
-  //Homepage component that have a navigation bar and render components based on the url
-  const [buttonRole, setButtonRole] = useState<string>("");
 
   return (
     <section className="homepage">

--- a/src/modules/Quest/Quest.scss
+++ b/src/modules/Quest/Quest.scss
@@ -50,8 +50,8 @@
   z-index: 2;
 
   &__action-card {
-    width: 19em;
-    height: 12em;
+    width: 21em;
+    height: 13.5em;
     cursor: pointer;
     background-size: 100%;
     margin: 2em;
@@ -112,4 +112,14 @@ h3 {
   position: absolute;
   left: 1em;
   top: 0.5em;
+}
+
+.complete-quest {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 85%;
+  justify-content: flex-start;
+  text-decoration: none;
+  position: relative;
 }

--- a/src/modules/Quest/Quest.scss
+++ b/src/modules/Quest/Quest.scss
@@ -28,6 +28,7 @@
   height: 85%;
   justify-content: center;
   text-decoration: none;
+  position: relative;
 }
 
 .encounter-story-container {
@@ -82,8 +83,8 @@
   width: 30em;
   height: 20px;
   position: absolute;
-  top: 16em;
-  right: 14em;
+  top: 2em;
+  right: 17em;
   float: right;
 }
 
@@ -101,9 +102,7 @@ h3 {
   height: 180px;
   width: 180px;
   position: absolute;
-  background-position: -155px -145px;
   right: 1em;
-  top: 0.5em;
 }
 
 .img-hero {

--- a/src/modules/Quest/index.tsx
+++ b/src/modules/Quest/index.tsx
@@ -1,35 +1,28 @@
-import { useEffect, useState } from "react";
-import "./Quest.scss";
-import {
-  QuestInProgress,
-  CurrentQuests,
-  ComponentPath,
-  ActionCards,
-  QuestEncounterFunctoinality,
-} from "../../interfaces";
-import testData from "../test_assets/mock_data";
-import { apiCalls } from "../../apiCalls";
-import HeroIdle from "../../assets/Hero/Hero_Idle.png";
-import HeartEmpty from "../../assets/Extras/Heart_Empty.png";
-import HeartFull from "../../assets/Extras/Heart_Full.png";
-import ActionStage from "../../assets/Extras/ActionStage.png";
-import MonsterAttack from "../../assets/Hero/Monster_Attack.png";
-import ActionCardOne from "../../assets/Action Cards/ActionCard_1.png";
-import ActionCardOneH from "../../assets/Action Cards/ActionCard_1_Hover.png";
-import ActionCardTwo from "../../assets/Action Cards/ActionCard_2.png";
-import ActionCardTwoH from "../../assets/Action Cards/ActionCard_2_Hover.png";
+import './Quest.scss'
+import { useEffect, useState } from 'react'
+import { QuestInProgress, CurrentQuests, ComponentPath, ActionCards, QuestEncounterFunctoinality, Heart } from '../../interfaces'
+import { apiCalls } from '../../apiCalls'
+import { useHistory } from 'react-router-dom'
+import HeroIdle from '../../assets/Hero/Hero_Idle.png'
+import HeartEmpty from '../../assets/Extras/Heart_Empty.png'
+import HeartFull from '../../assets/Extras/Heart_Full.png'
+import ActionStage from '../../assets/Extras/ActionStage.png'
+import ActionCardOne from '../../assets/Action Cards/ActionCard_1.png'
+import ActionCardOneH from '../../assets/Action Cards/ActionCard_1_Hover.png'
+import ActionCardTwo from '../../assets/Action Cards/ActionCard_2.png'
+import ActionCardTwoH from '../../assets/Action Cards/ActionCard_2_Hover.png'
 
 type CurrentQuest =
   | (ComponentPath & CurrentQuests)
   | QuestEncounterFunctoinality;
 
 const Quest: React.FC<CurrentQuest> = (props) => {
-  const [userProgress, setUserProgress] = useState<number>(1);
-  const [userQuest, setUserQuest] = useState<QuestInProgress | null>(null);
-  const [currentEncounter, setCurrentEncounter] = useState<any | null>(null);
-  const [isQuestCompleted, setIsQuestCompleted] = useState<boolean | false>(
-    false
-  );
+
+  const [userProgress, setUserProgress] = useState<number>(1)
+  const [userQuest, setUserQuest] = useState<QuestInProgress | null>(null)
+  const [currentEncounter, setCurrentEncounter] = useState<any | null>(null)
+  const [hearts, setHearts] = useState<Heart[]>([])
+  const [isQuestCompleted, setIsQuestCompleted] = useState<boolean | false>(false)
   const [questCards, setQuestCards] = useState<any>({
     cardOne: false,
     cardTwo: false,
@@ -37,115 +30,117 @@ const Quest: React.FC<CurrentQuest> = (props) => {
 
   const cardActions: ActionCards = {
     cardOne: [ActionCardOne, ActionCardOneH],
-    cardTwo: [ActionCardTwo, ActionCardTwoH],
-  };
-  const currentQuest: QuestInProgress = testData.quests[0];
-
-  const { match } = props as ComponentPath;
-  const { quests } = props as CurrentQuests;
-  const {
-    getQuest,
-    getEncounter,
-    getQuestDetails,
-    ...others
-  } = props as QuestEncounterFunctoinality;
-
-  // const encounters = testData.allEncounters
-  const getQuestInfo: typeof getQuest = async (id) => {
-    let newQuest = quests.find((quest) => quest.id === parseInt(id));
-    if (newQuest) {
-      setUserQuest(newQuest);
-      setUserProgress(newQuest.progress);
-      getEncounterInfo(questId, userProgress);
-    }
-  };
-
-  const getEncounterInfo: typeof getEncounter = async (
-    questId: string,
-    progressLevel: number
-  ) => {
-    return await Promise.resolve(
-      apiCalls.getQuestEncounter(parseInt(questId), progressLevel)
-    ).then((response) => {
-      console.log(response);
-      setCurrentEncounter(response.data.attributes);
-    });
-  };
-
-  const switchProgressLevel = () => {
-    let currentEncounter = {
-      quest_id: questId,
-      progress: `${userProgress}`,
-    };
-    apiCalls.patchUserQuest(currentEncounter).then((response) => {
-      setIsQuestCompleted(response.data.attributes.completion_status);
-      console.log(response);
-    });
-    if (!setIsQuestCompleted) {
-      setUserProgress(userProgress + 1);
-    } else {
-      console.log("User did not complete the quest");
-      //here we will add a comletion compoenent/message
-    }
-  };
-
+    cardTwo: [ActionCardTwo, ActionCardTwoH]
+  } 
+  const history = useHistory();
+  const {match} = props as ComponentPath
+  const {quests} = props as CurrentQuests
+  const {getQuest, getEncounter, getQuestDetails, ...others} = props as QuestEncounterFunctoinality
   const questId = match.params.id;
 
-  useEffect(() => {
-    getQuestInfo(questId);
-  }, [userProgress]);
+  const getQuestInfo: typeof getQuest = async (id) => {
+    let newQuest = quests.find(quest => quest.id === parseInt(id))
+    if(newQuest) {
+      setUserQuest(newQuest)
+      setUserProgress(newQuest.progress)
+      getEncounterInfo(questId, userProgress)
+      getMonsterHealth() 
+    }
+  }
 
-  console.log(userQuest);
+  const getMonsterHealth = () => {
+    let i = 0;
+    let heartsList: Heart[] = []
+    if(userQuest) {
+      while (i < userQuest.encounter_req) {
+        i++;
+        heartsList.push({
+          image: <img key={`heart-${i}`} className="monster-health" src={userProgress >= i ? HeartFull : HeartEmpty} alt="heart"/>,
+          id: i
+        })
+      }
+      setHearts(heartsList)
+    }
+  };
+
+  const getEncounterInfo: typeof getEncounter = async (questId: string, progressLevel: number) => {
+    return await Promise.resolve(apiCalls.getQuestEncounter(parseInt(questId), progressLevel))
+    .then((response) => {
+      setCurrentEncounter(response.data.attributes)})
+  }
+
+  const completeQuest = () => {
+    let lastEncounter = {
+      "quest_id": questId,
+      "progress": `${userProgress+1}`
+    }
+    apiCalls.patchUserQuest("8", lastEncounter)
+    .then((response) => {
+      setIsQuestCompleted(response.data.attributes.completion_status); 
+      history.push(`/quests`)
+    })
+  }
+
+  const switchProgressLevel = async () => {
+    let currentEncounter = {
+      "quest_id": questId,
+      "progress": `${userProgress}`
+    }
+    if(userQuest && userProgress < userQuest.encounter_req) {
+      return await Promise.resolve(apiCalls.patchUserQuest("1", currentEncounter))
+      .then((response) => {
+          setIsQuestCompleted(response.data.attributes.completion_status);
+     })
+    }
+    if(userQuest && userProgress === userQuest.encounter_req) {
+      apiCalls.patchUserQuest("7", currentEncounter)
+      .then((response) => {
+        setIsQuestCompleted(response.data.attributes.completion_status); 
+        setCurrentEncounter(null)
+      })
+    }
+  };
+
+  useEffect(() => {
+    getQuestInfo(questId)
+  }, [userQuest]);
+
+  useEffect(() => {
+    getEncounterInfo(questId, userProgress)
+  }, []);
 
   if (!userQuest || !currentEncounter) {
     return (
-      <section
-        data-cy="single-quest-container"
-        className="single-quest-container"
-      >
-        <h2 className="component-title">
-          Sorry, but this quest is unavailable
-        </h2>
+      <section data-cy="single-quest-container" className="page-quest-list">
+          <h2 className="component-title">You killed the moster!</h2>
+          <section className="quest-wrapper">
+              <div className="encounter-details__action-card"
+                style={{backgroundImage: `url(`+ `${questCards.cardOne ? cardActions.cardOne[1] : cardActions.cardOne[0]}`+`)`}}
+                onMouseOver={() => setQuestCards({...questCards, cardOne: true})}
+                onMouseOut={() => setQuestCards({...questCards, cardOne: false})}
+                onClick={completeQuest}>
+                  <p className="action-desc">Complete your Quest!</p>
+              </div>
+          </section>
       </section>
     );
   } else {
     return (
       <section data-cy="single-quest-container" className="page-quest-list">
         <h2 className="component-title">{userQuest.name}</h2>
-        {/* heart img */}
         <section className="quest-wrapper">
           <div className="monster-health-container">
-            <img
-              className="monster-health"
-              src={userProgress < 3 ? HeartFull : HeartEmpty}
-              alt="heart-1"
-            />
-            <img
-              className="monster-health"
-              src={userProgress >= 2 ? HeartFull : HeartEmpty}
-              alt="heart-2"
-            />
-            <img
-              className="monster-health"
-              src={userProgress === 1 ? HeartFull : HeartEmpty}
-              alt="heart-3"
-            />
+             {
+               hearts.map(img => img.image)
+             }
           </div>
           <div
             data-cy="encounter-story-container"
             className="encounter-story-container"
-            style={{ backgroundImage: `url(` + `${ActionStage}` + `)` }}
-          >
-            <div
-              className="img-hero"
-              style={{ backgroundImage: `url(` + `${HeroIdle}` + `)` }}
-            ></div>
-            {/* <img className="img-monster" src={currentEncounter.monster_image} alt="monster-pic"/>
-            needs an image to render, will be uncommented when we get full data*/}
-            <div
-              className="img-monster"
-              style={{ backgroundImage: `url(` + `${MonsterAttack}` + `)` }}
-            ></div>
+            style={{backgroundImage: `url(`+ `${ActionStage}`+`)`}} 
+            >
+            <div className="img-hero" style={{backgroundImage: `url(`+ `${HeroIdle}`+`)`}}></div>
+            <img className="img-monster" src={currentEncounter.monster_image} alt="monster-pic"/> 
           </div>
           <div data-cy="quest-details" className="single-quest-details">
             <h3 className="single-quest-details__title">
@@ -153,62 +148,32 @@ const Quest: React.FC<CurrentQuest> = (props) => {
             </h3>
             <h3 className="single-quest-details__title">{userQuest.xp} XP</h3>
           </div>
-          <div data-cy="action-cards-container" className="encounter-details">
-            <div
-              data-cy="action-card-left"
-              className="encounter-details__action-card"
-              style={{
-                backgroundImage:
-                  `url(` +
-                  `${
-                    questCards.cardOne
-                      ? cardActions.cardOne[1]
-                      : cardActions.cardOne[0]
-                  }` +
-                  `)`,
-              }}
-              onMouseOver={() =>
-                setQuestCards({ ...questCards, cardOne: true })
-              }
-              onMouseOut={() =>
-                setQuestCards({ ...questCards, cardOne: false })
-              }
-              onClick={switchProgressLevel}
-            >
-              {currentEncounter.actions[0] && (
-                <p className="action-desc">
-                  {currentEncounter.actions[0].description}
-                </p>
-              )}
+            <div data-cy="action-cards-container" className="encounter-details">
+              <div 
+                data-cy="action-card-left" 
+                className="encounter-details__action-card"
+                style={{backgroundImage: `url(`+ `${questCards.cardOne ? cardActions.cardOne[1] : cardActions.cardOne[0]}`+`)`}} 
+                onMouseOver={() => setQuestCards({...questCards, cardOne: true})}
+                onMouseOut={() => setQuestCards({...questCards, cardOne: false})}
+                onClick={switchProgressLevel}
+                >
+                {currentEncounter.actions[0] &&
+                <p className="action-desc">{currentEncounter.actions[0].description}</p>
+                } 
+              </div>
+              <div 
+                data-cy="action-card-right" 
+                className="encounter-details__action-card"
+                onMouseOver={() => setQuestCards({...questCards, cardTwo: true})}
+                onMouseOut={() => setQuestCards({...questCards, cardTwo: false})}
+                onClick={switchProgressLevel}
+                style={{backgroundImage: `url(`+ `${questCards.cardTwo ? cardActions.cardTwo[1] : cardActions.cardTwo[0]}`+`)`}} 
+                >
+                {currentEncounter.actions[1] &&
+                  <p className="action-desc">{currentEncounter.actions[1].description}</p>
+                } 
+              </div>
             </div>
-            <div
-              data-cy="action-card-right"
-              className="encounter-details__action-card"
-              onMouseOver={() =>
-                setQuestCards({ ...questCards, cardTwo: true })
-              }
-              onMouseOut={() =>
-                setQuestCards({ ...questCards, cardTwo: false })
-              }
-              onClick={switchProgressLevel}
-              style={{
-                backgroundImage:
-                  `url(` +
-                  `${
-                    questCards.cardTwo
-                      ? cardActions.cardTwo[1]
-                      : cardActions.cardTwo[0]
-                  }` +
-                  `)`,
-              }}
-            >
-              {currentEncounter.actions[1] && (
-                <p className="action-desc">
-                  {currentEncounter.actions[1].description}
-                </p>
-              )}
-            </div>
-          </div>
         </section>
       </section>
     );

--- a/src/modules/Quest/index.tsx
+++ b/src/modules/Quest/index.tsx
@@ -113,7 +113,7 @@ const Quest: React.FC<CurrentQuest> = (props) => {
     return (
       <section data-cy="single-quest-container" className="page-quest-list">
           <h2 className="component-title">You killed the moster!</h2>
-          <section className="quest-wrapper">
+          <section className="complete-quest">
               <div className="encounter-details__action-card"
                 style={{backgroundImage: `url(`+ `${questCards.cardOne ? cardActions.cardOne[1] : cardActions.cardOne[0]}`+`)`}}
                 onMouseOver={() => setQuestCards({...questCards, cardOne: true})}

--- a/src/modules/Quest/index.tsx
+++ b/src/modules/Quest/index.tsx
@@ -66,8 +66,13 @@ const Quest: React.FC<CurrentQuest> = (props) => {
   const getEncounterInfo: typeof getEncounter = async (questId: string, progressLevel: number) => {
     return await Promise.resolve(apiCalls.getQuestEncounter(parseInt(questId), progressLevel))
     .then((response) => {
-      setCurrentEncounter(response.data.attributes)})
-  }
+      if(response.ok) {
+        setCurrentEncounter(response.data.attributes)
+      } else {
+        setCurrentEncounter(null)
+      }
+  })
+}
 
   const completeQuest = () => {
     let lastEncounter = {

--- a/src/modules/QuestsList/index.tsx
+++ b/src/modules/QuestsList/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import {Link} from 'react-router-dom'
 import "./QuestsList.scss";
-import { CurrentQuests, ComponentPath, CardTypeObj } from '../../interfaces'
+import { CurrentQuests, ComponentPath, CardTypeObj, QuestEncounterFunctoinality } from '../../interfaces'
 import questCardActive from '../../assets/Quest Cards/QuestCard_Active.png'
 import questCardActiveH from '../../assets/Quest Cards/QuestCard_Active_Hover.png'
 import questCardPassive from '../../assets/Quest Cards/QuestCard_Passive.png'
@@ -9,10 +9,11 @@ import questCardPassiveH from '../../assets/Quest Cards/QuestCard_Passive_Hover.
 import questCardSupportive from '../../assets/Quest Cards/QuestCard_Supportive.png'
 import questCardSupportiveH from '../../assets/Quest Cards/QuestCard_Supportive_Hover.png'
 
-type QuestProps = CurrentQuests & ComponentPath
+type QuestProps = CurrentQuests & ComponentPath | QuestEncounterFunctoinality
 
 const QuestList: React.FC<QuestProps> = (props) => {
-  const {quests} = props
+  const {quests} = props as CurrentQuests
+  const {getQuestDetails} = props as QuestEncounterFunctoinality
   const [questTypes, setQuestTypes] = useState<object>({
     active: false,
     passive: false,
@@ -32,7 +33,6 @@ const QuestList: React.FC<QuestProps> = (props) => {
       </section>
     )
   } else {
-    console.log(quests)
     return (
       <section data-cy="quests-list-container" className="page-quest-list">
         <h2 className="component-title">Available Quests</h2>

--- a/src/modules/QuestsList/index.tsx
+++ b/src/modules/QuestsList/index.tsx
@@ -12,14 +12,12 @@ import questCardSupportiveH from '../../assets/Quest Cards/QuestCard_Supportive_
 type QuestProps = CurrentQuests & ComponentPath
 
 const QuestList: React.FC<QuestProps> = (props) => {
-  const {match, quests} = props
+  const {quests} = props
   const [questTypes, setQuestTypes] = useState<object>({
     active: false,
     passive: false,
     supportive: false
   })
-
-  const [currentQuest, setCurrentQuest] = useState<object>({})
 
   const cardTypes: CardTypeObj  = {
     active: [questCardActive, questCardActiveH],
@@ -34,6 +32,7 @@ const QuestList: React.FC<QuestProps> = (props) => {
       </section>
     )
   } else {
+    console.log(quests)
     return (
       <section data-cy="quests-list-container" className="page-quest-list">
         <h2 className="component-title">Available Quests</h2>
@@ -49,19 +48,19 @@ const QuestList: React.FC<QuestProps> = (props) => {
                 data-cy={`quest-${quest.type}`} 
                 to={`/quests/${quest.id}`}
               >
-              <div className="quest-card-inner-wrapper"> 
-                <h2 className="quests-card-title">{quest.name}</h2>
-                <div className="quest-card-inner-box">
-                  <div className="quest-card-wrapper__left-side">
-                    <p className="quests-card-details">{quest.xp} XP</p>
-                    <p className="quests-card-details">Encounters: {quest.encounter_req}</p>
-                  </div>
-                  <div className="quest-card-wrapper__right-side">
-                    <p className="quests-card-details">Level {quest.level}</p>
-                    <p className="quests-card-details">{quest.type}</p>
+                <div className="quest-card-inner-wrapper"> 
+                  <h2 className="quests-card-title">{quest.name}</h2>
+                  <div className="quest-card-inner-box">
+                    <div className="quest-card-wrapper__left-side">
+                      <p className="quests-card-details">{quest.xp} XP</p>
+                      <p className="quests-card-details">Encounters: {quest.encounter_req}</p>
+                    </div>
+                    <div className="quest-card-wrapper__right-side">
+                      <p className="quests-card-details">Level {quest.level}</p>
+                      <p className="quests-card-details">{quest.type}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
             </Link> 
           )}
         </section>

--- a/src/modules/User/index.tsx
+++ b/src/modules/User/index.tsx
@@ -1,24 +1,7 @@
-// import { promises } from "fs";
-// import { useEffect, useState } from "react";
-// import { apiCalls } from "../../apiCalls";
+import { ProfileObject } from '../../interfaces'
+
 import heroImage from "../../assets/Extras/Hero.png";
 import "./Profile.scss";
-
-interface UserProfile {
-  username: string;
-  email: string;
-  xp: number;
-}
-
-interface ProfileObject {
-  user: UserProfile;
-}
-
-// const userOne: UserProfile = {
-//   username: "Tom",
-//   email: "user@gmail.com",
-//   xp: 1000,
-// };
 
 const Profile: React.FC<ProfileObject> = ({ user }) => {
   return (

--- a/src/modules/UserQuestLog/index.tsx
+++ b/src/modules/UserQuestLog/index.tsx
@@ -1,20 +1,5 @@
 import "./QuestLog.scss";
-
-interface idObject {
-  id: number;
-}
-
-interface Quest extends idObject {
-  name: string;
-  xp: number;
-  encounter_req: number;
-  type: string;
-  progress: number;
-}
-
-interface CompletedQuests {
-  completedQuests: Array<Quest>;
-}
+import { idObject, Quest, CompletedQuests } from '../../interfaces'
 
 const UserQuestLog: React.FC<CompletedQuests> = ({ completedQuests }) => {
   if (completedQuests) {


### PR DESCRIPTION
### Description
Add a feature that sends users to a complete quest page to finish the quest on the last encounter.
When user clicks complete quest, the page should redirect user to Available Quests page
Now monster health is generated based on the encounter number

Clean unused variables
Move all interfaces to interface file

### Closes issue(s)

### Testing

### Screenshots

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [ ] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [ ] I ran rubocop and fixed issues
- [ ] I ran full test suite - all tests passing 

### Other comments
We need to add an error handler for failed fetch requests